### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Deploy to GitHub Pages
 permissions:
-  contents: read
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/cute-omega/config_convert/security/code-scanning/1](https://github.com/cute-omega/config_convert/security/code-scanning/1)

**General fix:**  
Explicitly set the `permissions` block at the root of the workflow or within the specific job to specify the exact permissions required by the workflow. As a minimal starting point, set `permissions` to `contents: read` (or narrower, if possible). If the workflow requires additional permissions (for example, to interact with issues or pull requests), specify them in the `permissions` section as well.

**Single best way for this workflow:**  
Since the workflow does not appear to use the `GITHUB_TOKEN` for any write operations (pushing is done with a PAT secret), the minimal necessary permission is likely `contents: read`. Put the block near the top of the file, after the `name` key and before `on:` (this sets the permissions for all jobs in the workflow).

**Edit instructions:**  
- Edit `.github/workflows/main.yml`
- Insert the following lines after the `name:` line:
  ```yaml
  permissions:
    contents: read
  ```
No other changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
